### PR TITLE
check when convert error to net.Error

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -131,7 +131,7 @@ func (c *Client) DialContext(ctx context.Context) (*Conn, error) {
 	}
 	stream, err := session.OpenStreamSync(ctx)
 	if err != nil {
-		if !err.(net.Error).Temporary() {
+		if ne, ok := err.(net.Error); ok && !ne.Temporary() {
 			// start over again when seeing unrecoverable error.
 			c.clearSession(err.Error())
 		}


### PR DESCRIPTION
To fix this panic I saw by chance
```
panic: interface conversion: *errors.errorString is not net.Error: missing method Temporary

goroutine 1337 [running]:
github.com/getlantern/quicwrapper.(*Client).DialContext(0xc003c7a5f0, 0x60b34e0, 0xc0034504e0, 0x400f948, 0x10, 0x59b05a0)
	/Users/joesis/go/pkg/mod/github.com/getlantern/quicwrapper@v0.0.0-20200708222210-66fc59a379b5/dialer.go:134 +0x1cf
github.com/getlantern/flashlight/chained.(*quicImpl).dialServer.func1(0xc0060d8f20, 0x5b4b7e8, 0xa, 0x59c7060)
	/Users/joesis/workspace/go/src/github.com/getlantern/flashlight/chained/quic_impl.go:89 +0x89
...
```