### PR TITLE
Upgrade quic-go module to allow for BBR improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,4 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )
 
-replace github.com/lucas-clemente/quic-go => github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd
+replace github.com/lucas-clemente/quic-go => github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f h1:wrYrQttPS8FHIRSl
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd h1:MoN0qJW/2JOLa96uFcpVJGNDKqDTax21vD2cRgZ7JtQ=
 github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
+github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b h1:H+yhPm5w5HiO7Y/ZZniTVEdYh2og3GDBP0TKcs40+K8=
+github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=


### PR DESCRIPTION
I struggled hard against sumdb and goproxy on this one, the
magic rune you need to cast is:

```
go env -w GOPRIVATE=github.com/getlantern/quic-go
```

and then everything works fine. My express displeasure goes
out to the sum proxy for having little to no debug output

---

WARNING - This template is public, do not include any sensitive information

- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [X] Can it be QA’d in staging or something like staging?
- [X] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [X] Do we know how we’re going to deploy this?
- [X] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?