### PR TITLE
bump quic-go deps to fix lack-of-bbr bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )
 
-replace github.com/lucas-clemente/quic-go => github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b
+replace github.com/lucas-clemente/quic-go => github.com/getlantern/quic-go v0.7.1-0.20210430204126-20cddf3612a7

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd h1:MoN0qJW/2JOL
 github.com/getlantern/quic-go v0.0.0-20201013165432-d264463d99fd/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b h1:H+yhPm5w5HiO7Y/ZZniTVEdYh2og3GDBP0TKcs40+K8=
 github.com/getlantern/quic-go v0.7.1-0.20210422183034-b5805f4c233b/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
+github.com/getlantern/quic-go v0.7.1-0.20210430204126-20cddf3612a7 h1:CMc0LdSK777Q+yVGd12eADYLkfCU+TfQDyNp1iRyIYU=
+github.com/getlantern/quic-go v0.7.1-0.20210430204126-20cddf3612a7/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=


### PR DESCRIPTION
See https://github.com/getlantern/quic-go/pull/21 

WARNING - This template is public, do not include any sensitive information

- [x] Do the tests pass? Consistently?
- [ ] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [x] Do we know how we’re going to deploy this?
- [x] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?