### PR TITLE
Separate the datagram chunking logic and fix possible overflow in ReadFrom()

### DIFF
--- a/webt/datagram.go
+++ b/webt/datagram.go
@@ -1,0 +1,128 @@
+package webt
+
+import (
+	"encoding/binary"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// WebTransport datagram uses QUIC datagram frames, with the minimum MTU (max transmission unit) being 1200 bytes which includes
+// QUIC header and WebTransport header. Let's just use a smaller safe size to avoid hitting maximum packet size.
+const maxDatagramSize = 1024
+
+// DatagramChunker handles chunking and reassemly of datagram payloads
+type DatagramChunker struct {
+	mutex     sync.Mutex
+	buffers   map[uint32]*messageBuffer // pending messages
+	inbox     chan []byte               // queue for reassembled messages
+	closed    bool
+	msgIDSeed uint32 // atomic counter
+}
+
+// messageBuffer stores chunks of a message until it's fully received
+type messageBuffer struct {
+	chunks    [][]byte
+	total     int
+	received  int
+	timestamp time.Time
+}
+
+// assembleChunks merges chunks
+func assembleChunks(chunks [][]byte) []byte {
+	var fullMessage []byte
+	for _, chunk := range chunks {
+		fullMessage = append(fullMessage, chunk...)
+	}
+	return fullMessage
+}
+
+// Receive processes a datagram chunk, assembles them, and queues complete messages that will be returned from Read()
+func (dc *DatagramChunker) Receive(data []byte) {
+	if len(data) < 12 {
+		log.Debugf("invalid datagram (too small)")
+		return
+	}
+
+	msgID := binary.BigEndian.Uint32(data[0:4])
+	chunkIndex := binary.BigEndian.Uint32(data[4:8])
+	totalChunks := binary.BigEndian.Uint32(data[8:12])
+	payload := data[12:]
+
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+
+	buf, exists := dc.buffers[msgID]
+	if !exists {
+		buf = &messageBuffer{
+			chunks:    make([][]byte, totalChunks),
+			total:     int(totalChunks),
+			timestamp: time.Now(),
+		}
+		dc.buffers[msgID] = buf
+	}
+	if int(chunkIndex) >= len(buf.chunks) {
+		log.Errorf("chunkIndex %d out of bounds for msg %d", chunkIndex, msgID)
+		return
+	}
+	if buf.chunks[chunkIndex] == nil {
+		buf.chunks[chunkIndex] = payload
+		buf.received++
+	}
+
+	if buf.received == buf.total {
+		full := assembleChunks(buf.chunks)
+		delete(dc.buffers, msgID)
+		if !dc.closed {
+			dc.inbox <- full
+		}
+	}
+}
+
+// Read returns the complete/assembled message
+func (dc *DatagramChunker) Read() ([]byte, error) {
+	msg, ok := <-dc.inbox
+	if !ok {
+		return nil, io.EOF
+	}
+	return msg, nil
+}
+
+// Chunk splits a message into datagram chunks to be sent over the wire
+func (dc *DatagramChunker) Chunk(p []byte) [][]byte {
+	totalChunks := (len(p) + maxDatagramSize - 1) / maxDatagramSize
+	msgID := atomic.AddUint32(&dc.msgIDSeed, 1)
+	var chunks [][]byte
+
+	for i := 0; i < totalChunks; i++ {
+		start := i * maxDatagramSize
+		end := min(start+maxDatagramSize, len(p))
+
+		header := make([]byte, 12)
+		binary.BigEndian.PutUint32(header[0:4], msgID)
+		binary.BigEndian.PutUint32(header[4:8], uint32(i))
+		binary.BigEndian.PutUint32(header[8:12], uint32(totalChunks))
+
+		chunks = append(chunks, append(header, p[start:end]...))
+	}
+	return chunks
+}
+
+// Close disposes of the instance. After calling Close() the instance can not be used anymore
+func (dc *DatagramChunker) Close() {
+	dc.mutex.Lock()
+	defer dc.mutex.Unlock()
+	if !dc.closed {
+		close(dc.inbox)
+		dc.closed = true
+	}
+}
+
+// NewDatagramChunker creates a new ChunkedDatagramHandler that handles chunking and reassembly of datagram payloads
+func NewDatagramChunker() *DatagramChunker {
+	return &DatagramChunker{
+		buffers: make(map[uint32]*messageBuffer),
+		inbox:   make(chan []byte, 100),
+	}
+}

--- a/webt/datagram_test.go
+++ b/webt/datagram_test.go
@@ -1,0 +1,49 @@
+package webt
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatagramChunker(t *testing.T) {
+	wg := &sync.WaitGroup{}
+
+	for range 1000 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			h := NewDatagramChunker()
+			defer h.Close()
+			// generate test random data
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			original := make([]byte, 1024*(r.Intn(1024)+2)) // at least 2KB
+			_, err := io.ReadFull(r, original)
+			require.NoError(t, err, "unable to generate random data")
+
+			// split to chunks
+			chunks := h.Chunk(original)
+			require.Greater(t, len(chunks), 1, "expected multiple chunks, got %d", len(chunks))
+
+			// shuffle chunks to simulate out-of-order delivery
+			r.Shuffle(len(chunks), func(i, j int) { chunks[i], chunks[j] = chunks[j], chunks[i] })
+
+			// feed shuffled chunks
+			for _, chunk := range chunks {
+				h.Receive(chunk)
+			}
+
+			// read reassembled message
+			reassembled, err := h.Read()
+			require.NoError(t, err, "unexpected error reading message: %v", err)
+			assert.True(t, bytes.Equal(reassembled, original), "reassembled message does not match original")
+		}()
+	}
+	wg.Wait()
+}

--- a/webt/listener.go
+++ b/webt/listener.go
@@ -55,6 +55,10 @@ func ListenAddr(options *ListenOptions) (net.Listener, error) {
 			TLSConfig:  options.TLSConfig,
 			QUICConfig: options.QUICConfig,
 		},
+		// allow any origin
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
 	}
 
 	udpAddr, err := net.ResolveUDPAddr("udp", options.Addr)
@@ -159,7 +163,7 @@ func (l *listener) listenAndServe() {
 func (l *listener) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 	session, err := l.server.Upgrade(w, r)
 	if err != nil {
-		fmt.Printf("upgrading failed: %s", err)
+		log.Errorf("webtransport upgrade failed: %s", err)
 		w.WriteHeader(500)
 		return
 	}

--- a/webt/packetconn.go
+++ b/webt/packetconn.go
@@ -2,19 +2,12 @@ package webt
 
 import (
 	"context"
-	"encoding/binary"
-	"errors"
-	"math/rand"
 	"net"
 	"sync"
 	"time"
 
 	"github.com/quic-go/webtransport-go"
 )
-
-// WebTransport datagram uses QUIC datagram frames, with the minimum MTU (max transmission unit) being 1200 bytes which includes
-// QUIC header and WebTransport header. Let's just use a smaller safe size to avoid hitting maximum packet size.
-const maxDatagramSize = 1024
 
 // map[*webtransport.Session]*refCountedConn that maps a WebTransport session to a reference counted packetConn
 var connMap sync.Map
@@ -88,24 +81,12 @@ func (h *refCountedConnHandle) SetWriteDeadline(t time.Time) error {
 // packetConn wraps a WebTransport session and implements net.PacketConn
 type packetConn struct {
 	session *webtransport.Session
-
-	mutex   sync.Mutex
-	inbox   chan []byte               // the queue for reassembled messages
-	buffers map[uint32]*messageBuffer // pending messages
+	chunker *DatagramChunker
 
 	// keep-alive interval that periodically sends "ping" messages to the peer to avoid QUIC idle timeout error
 	keepAliveInterval time.Duration
-
-	ctx    context.Context
-	cancel context.CancelFunc
-}
-
-// messageBuffer stores chunks of a message until it's fully received
-type messageBuffer struct {
-	chunks    [][]byte
-	total     int
-	received  int
-	timestamp time.Time
+	ctx               context.Context
+	cancel            context.CancelFunc
 }
 
 // receiveDatagrams listens for incoming datagrams as chunks, reassembles them, and queues complete messages
@@ -113,7 +94,7 @@ func (c *packetConn) receiveDatagrams() {
 	for {
 		select {
 		case <-c.ctx.Done():
-			close(c.inbox)
+			c.chunker.Close()
 			log.Trace("receiveDatagrams context done")
 			return
 		default:
@@ -121,7 +102,7 @@ func (c *packetConn) receiveDatagrams() {
 			data, err := c.session.ReceiveDatagram(c.ctx)
 			if err != nil {
 				log.Tracef("receiveDatagrams error: %v", err)
-				close(c.inbox)
+				c.chunker.Close()
 				return
 			}
 
@@ -129,90 +110,31 @@ func (c *packetConn) receiveDatagrams() {
 			if len(data) == 4 && string(data) == "ping" {
 				continue
 			}
-
-			if len(data) < 12 {
-				log.Debugf("receiveDatagrams invalid datagram (too small)")
-				continue
-			}
-
-			// header: msgID, chunkIndex, totalChunks
-			msgID := binary.BigEndian.Uint32(data[0:4])
-			chunkIndex := binary.BigEndian.Uint32(data[4:8])
-			totalChunks := binary.BigEndian.Uint32(data[8:12])
-			payload := data[12:]
-
-			c.mutex.Lock()
-
-			// initialize buffer (new message)
-			if _, exists := c.buffers[msgID]; !exists {
-				c.buffers[msgID] = &messageBuffer{
-					chunks:    make([][]byte, totalChunks),
-					total:     int(totalChunks),
-					received:  0,
-					timestamp: time.Now(),
-				}
-			}
-
-			buffer := c.buffers[msgID]
-			if buffer.chunks[chunkIndex] == nil {
-				buffer.chunks[chunkIndex] = payload
-				buffer.received++
-			}
-
-			// if all chunks have arrived, reassemble and queue the message
-			if buffer.received == buffer.total {
-				fullMessage := assembleMessage(buffer.chunks)
-				delete(c.buffers, msgID)
-				c.inbox <- fullMessage
-			}
-
-			c.mutex.Unlock()
+			c.chunker.Receive(data)
 		}
 	}
 }
 
-// assembleMessage merges chunks
-func assembleMessage(chunks [][]byte) []byte {
-	var fullMessage []byte
-	for _, chunk := range chunks {
-		fullMessage = append(fullMessage, chunk...)
-	}
-	return fullMessage
-}
-
 // ReadFrom waits for a complete message and returns it
 func (c *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	msg, ok := <-c.inbox
-	if !ok {
-		return 0, nil, errors.New("connection closed")
+	msg, err := c.chunker.Read()
+	if err != nil {
+		return 0, nil, err
 	}
-
 	copy(p, msg)
 	log.Tracef("packetConn.ReadFrom: Received %v bytes from %v", len(msg), c.session.RemoteAddr())
 	return len(msg), c.session.RemoteAddr(), nil
 }
 
 // WriteTo splits large messages and sends them as datagram chunks
-func (c *packetConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
-	totalChunks := (len(p) + maxDatagramSize - 1) / maxDatagramSize
-	msgID := uint32(rand.Int31()) // unique message ID
-
-	for i := range totalChunks {
-		start := i * maxDatagramSize
-		end := min(start+maxDatagramSize, len(p))
-
-		// header: 4-byte msgID, 4-byte chunkIndex, 4-byte totalChunks
-		header := make([]byte, 12)
-		binary.BigEndian.PutUint32(header[0:4], msgID)
-		binary.BigEndian.PutUint32(header[4:8], uint32(i))
-		binary.BigEndian.PutUint32(header[8:12], uint32(totalChunks))
-
-		packet := append(header, p[start:end]...)
-		if err := c.session.SendDatagram(packet); err != nil {
+func (c *packetConn) WriteTo(p []byte, _ net.Addr) (n int, err error) {
+	chunks := c.chunker.Chunk(p)
+	for _, chunk := range chunks {
+		if err := c.session.SendDatagram(chunk); err != nil {
 			return 0, err
 		}
 	}
-	log.Tracef("packetConn.WriteTo: Sent %v bytes of %v chunks", len(p), totalChunks)
+	log.Tracef("packetConn.WriteTo: Sent %v bytes of %v chunks", len(p), len(chunks))
 	return len(p), nil
 }
 
@@ -257,8 +179,7 @@ func newPacketConn(session *webtransport.Session, keepAlive time.Duration) net.P
 	ctx, cancel := context.WithCancel(context.Background())
 	conn := &packetConn{
 		session:           session,
-		inbox:             make(chan []byte, 100),
-		buffers:           make(map[uint32]*messageBuffer),
+		chunker:           NewDatagramChunker(),
 		keepAliveInterval: keepAlive,
 		ctx:               ctx,
 		cancel:            cancel,


### PR DESCRIPTION
This PR is part of [1393](https://github.com/getlantern/engineering/issues/1393) that should be merged before having webtransport in WASM.

- **Separate the datagram chunking logic into a new API for unbounded**: the chunking is needed to avoid hitting max datagram packet size and was unexported in the packetconn.go. We need this in the WASM webtransport implementation as well hence separate it into another object.
- **allow any origin in webtransport listener**: this is needed to support webtransport clients originated from the browsers because browsers may set the Origin header, and the default behavior in webtransport-go is that the Origin header should match the request's Host header. If not, it server will reject this connection.
- Fix a bug that may cause possible buffer overflow in ReadFrom() in `packetConn`